### PR TITLE
Built some tests for mention, fixed hashtag problem

### DIFF
--- a/test/fixtures/lesson.yml
+++ b/test/fixtures/lesson.yml
@@ -1,0 +1,9 @@
+test_lesson:
+  hash_tag: "#test"
+  category: "test"
+  description: "a test lesson"
+
+test_lesson_two:
+  hash_tag: "#test_two"
+  category: "test"
+  description: "a second test lesson"

--- a/test/models/mentions_test.rb
+++ b/test/models/mentions_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class MentionsTest < ActiveSupport::TestCase
+	test "Given a well formatted tweet, generate_mention should make a mention" do
+		tweet = generate_tweet("@target hey @tweechable please help #test")
+		Mention.generate_mention(tweet)
+		assert_equal(1, Mention.count, "A new tweet should have been created")
+	end
+
+	test "If a tweet doesn't have a hashtag, no mention should be generated" do
+		tweet = generate_tweet("@target hey @tweechable please help test")
+		Mention.generate_mention(tweet)
+		assert_equal(0, Mention.count, "A new tweet shouldn't have been created")
+	end
+
+	test "If a tweet has a hashtag but it doesn't match any lessons, don't generate a mention" do
+		tweet = generate_tweet("@target hey @tweechable please help #hashtag #blashtag")
+		Mention.generate_mention(tweet)
+		assert_equal(0, Mention.count, "A new tweet shouldn't have been created")
+	end
+
+	test "If a tweet don't have a target, don't generate a mention" do
+		tweet = generate_tweet("I think @tweechable is a good service.")
+		Mention.generate_mention(tweet)
+		assert_equal(0, Mention.count, "A new tweet shouldn't have been created")
+	end
+
+	test "A mention shouldn't be generate for if we've already done that mention" do
+		tweet = generate_tweet("@target hey @tweechable please help #test")
+		Mention.generate_mention(tweet)
+		assert_equal(1, Mention.count, "A new tweet should have been created")
+
+		Mention.generate_mention(tweet)
+		assert_equal(1, Mention.count, "A tweet shouldn't have been created")
+	end
+
+	# tweet with multiple hashtags, the correct one isn't first
+
+	# Tweet with multiple valid hashtags
+
+	# Tweet with multiple targets
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,4 +7,12 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  def generate_tweet(text)
+  	Twitter::Tweet.new({id: 1, 
+						favorite_count: 0,
+            lang: "en", 
+						retweet_count: 0, 
+						source: "@tweeter",
+						text: text})
+  end
 end


### PR DESCRIPTION
In my attempts to fix the twitter bot on Tuesday, I ended up breaking it a bunch of different times. To avoid this sort of thing happening in the future, I wrote some tests for how Mentions processes tweets.  The tests should try out some of the various kinds of tweets @tweechable might encounter and check if it creates a mention or not.