### PR TITLE
Added will_paginate intializer to fix admin panel

### DIFF
--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -1,0 +1,13 @@
+if defined?(WillPaginate)
+  module WillPaginate
+    module ActiveRecord
+      module RelationMethods
+        def per(value = nil) per_page(value) end
+        def total_count() count end
+      end
+    end
+    module CollectionMethods
+      alias_method :num_pages, :total_pages
+    end
+  end
+end


### PR DESCRIPTION
I've added an intializer (`will_paginate.rb`) which fixes incompatibilities between the will_paginate and katimari gems, which was preventing viewing any models on the admin_panel. Fix sourced from [this article](http://tech-brains.blogspot.in/2012/11/kaminari-willpaginate-incompatibility.html). Someone else also had the same issue with `rails_admin`, see [here](https://github.com/sferik/rails_admin/issues/1420) for that.