### PR TITLE
Lessons Search Fix

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -11,7 +11,7 @@ class LessonsController < ApplicationController
     @lessons = Lesson.where(approved: true).paginate(:page => params[:page], :per_page => 10)
     @lessons_all = Lesson.all
     if params[:keyword].present?
-      @lessons = @lessons_all.where("hash_tag LIKE ? OR description LIKE ? OR category LIKE ?", "%#{params[:keyword]}%", "%#{params[:keyword]}%","%#{params[:keyword]}%").paginate(:page => params[:page], :per_page => 1)
+      @lessons = @lessons_all.where("hash_tag LIKE ? OR description LIKE ? OR category LIKE ?", "%#{params[:keyword]}%", "%#{params[:keyword]}%","%#{params[:keyword]}%").paginate(:page => params[:page], :per_page => 10)
     end
 
     respond_to do |format|

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -11,7 +11,7 @@ class LessonsController < ApplicationController
     @lessons = Lesson.where(approved: true).paginate(:page => params[:page], :per_page => 10)
     @lessons_all = Lesson.all
     if params[:keyword].present?
-      @lessons = @lessons_all.where("hash_tag LIKE ? OR description LIKE ? OR category LIKE ?", "%#{params[:keyword]}%", "%#{params[:keyword]}%","%#{params[:keyword]}%")
+      @lessons = @lessons_all.where("hash_tag LIKE ? OR description LIKE ? OR category LIKE ?", "%#{params[:keyword]}%", "%#{params[:keyword]}%","%#{params[:keyword]}%").paginate(:page => params[:page], :per_page => 1)
     end
 
     respond_to do |format|

--- a/app/views/lessons/index.html.erb
+++ b/app/views/lessons/index.html.erb
@@ -16,13 +16,20 @@
 
 <br>
 <div class="row">
-  <% @lessons.each do |lesson| %>
-      <div class="col-md-4">
-        <h3><%= link_to lesson.hash_tag, lesson_path(lesson.id) %></h3>
-        <% lesson.tweets.each do |tweet| %>
-        <p><%= tweet.text %></p>
-        <% end %>
-      </div>
+  <% if params[:keyword].present? #if this is a search %>
+    <h2>Lessons Matching: "<i><%= params[:keyword] %></i>"</h2>
+  <% end %>
+  <% unless @lessons.empty? %>
+    <% @lessons.each do |lesson| %>
+        <div class="col-md-4">
+          <h3><%= link_to lesson.hash_tag, lesson_path(lesson.id) %></h3>
+          <% lesson.tweets.each do |tweet| %>
+          <p><%= tweet.text %></p>
+          <% end %>
+        </div>
+    <% end %>
+  <% else %>
+    No results found! Consider creating a new lesson if you're looking for something worthwhile!
   <% end %>
 </div>
 


### PR DESCRIPTION
Fixed the lessons search not working due to pagination not being applied, and also made it so that when searching for a lesson text is printed indicating what you are seeing results for. If you happen to not find any results, a message is printed indicating this as well.