### PR TITLE
Removed "Try Tweechable" page 

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -23,7 +23,6 @@
                 end
         %></li>
         <li><%= link_to "Why Tweechable", '/pages/about' %></li>
-        <li><%= link_to "Try Tweechable", '/educatees/new' %></li>
         <li><%= link_to "Team", '/pages/team' %></li>
       </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
   get '/pages/:page' => 'pages#show'
 
-  get '/educatees/new' => 'educatees#new'
+  # get '/educatees/new' => 'educatees#new' - Try Tweechable page, removed per issue #41
   get '/educatees' => 'educatees#index'
   post '/educatees' => 'educatees#create'
 


### PR DESCRIPTION
Per #41 where it was indicated that the Try Tweechable page had potential security risks, the Try Tweechable page has been removed from navigation and from routing to prevent any possible exploits.