### PR TITLE
Updated gitignore to ignore Sublime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@
 !/log/.keep
 /tmp
 
-/app/models/twitter_api.rb
+# Ignore Sublime files
+*sublime*


### PR DESCRIPTION
Just wanted to fix Sublime files being tracked, and I wanted to fix git tracking my local changes to `twitter_api.rb` (since I had entered my own personal Twitter API info), but that's not possible due to it already being in history and being tracked. Since we need that file in production, and the `.gitignore` rule for it didn't work anyway, I removed that rule as well.