### PR TITLE
Fix ChiHack Slack link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Idea originated at [Chi Hack Night](https://chihacknight.org/).
 - [Tweechable Website](https://tweechable.herokuapp.com/)
 - Twitter: #tweechablemoments and [@tweechable](https://twitter.com/tweechable)
 - [Chi Hack Night Work group](https://chihacknight.org/breakouts.html)
-- [Join the tweechable-moments channel on the ChiHackNight slack] (slackme.chihacknight.org)
+- [Join the tweechable-moments channel on the ChiHackNight slack] (http://slackme.chihacknight.org)
 
 ### Tech Stack
 


### PR DESCRIPTION
The 'http://' was missing from the url and Github assumed it was a
relative URL. Corrected to link to 'http://slackme.chihacknight.org/'