### PR TITLE
Remove Team Page from Navigation

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -23,7 +23,6 @@
                 end
         %></li>
         <li><%= link_to "Why Tweechable", '/pages/about' %></li>
-        <li><%= link_to "Team", '/pages/team' %></li>
       </ul>
 
       <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
This deals with Issue #85. Due to the modular nature of the pages, I cannot remove the routing for this individual page without adding some nasty exceptions, so I've left it in. Alternatively, I could delete the whole page's template file, so let me know if that is desired.