### PR TITLE
remove team link from navbar

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -17,7 +17,6 @@
         <li><%= link_to "Browse Lessons", lessons_path %></li>
         <li><%= link_to "Why Tweechable", '/pages/about' %></li>
 
-        <li><%= link_to "Team", '/pages/team' %></li>
         <% if User.find_by(id: session["user_id"]) && User.find_by(id: session["user_id"]).admin %>
           <li>
             <%= link_to "Admin", '/pages/admin' %>


### PR DESCRIPTION
Hi, after approving PR #72 where @TheJhyde had removed the team page, I belatedly realized that the link to team was still in the nav bar.  I removed it, but I'm also not sure what happened, because I think @vkoves had already removed it in commit [5864dfda2687d6ab6dbc04df31b8296412e47aa5](https://github.com/Tweechable/tweechable_final/commit/5864dfda2687d6ab6dbc04df31b8296412e47aa5)?  Maybe the change was overwritten by merge to master since then.  Thanks in advance to whoever approves this one-line PR!