### PR TITLE
Fixed Styling of Login and Sign Up

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -35,4 +35,23 @@ div.form-container {
     }
   }
 
+  .checkbox-inline {
+    width: 100%;
+    max-width: 450px;
+    margin: auto;
+    padding-left: 0px;
+  }
+
+  .checkbox-inline input[type="checkbox"]
+  {
+    float: left;
+    position: relative;
+    margin: 3px 0px;
+  }
+
+  .checkbox-inline label {
+    text-align: left;
+    padding-left: 30px;
+    margin-top: 0px;
+  }
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -55,3 +55,5 @@ div.form-container {
     margin-top: 0px;
   }
 }
+
+.devise-links { margin-top: 10px; }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,12 +6,12 @@
     <%= devise_error_messages! %>
 
     <div class="form-group">
-      <%= f.label :username, class: 'sr-only' %><br />
+      <%= f.label :username, class: 'sr-only' %>
       <%= f.text_field :username, size: 40, autofocus: true, required: true, placeholder: 'Username' %>
     </div>
 
     <div class="form-group">
-      <%= f.label :email, class: 'sr-only' %><br />
+      <%= f.label :email, class: 'sr-only' %>
       <%= f.email_field :email, size: 40, required: true, placeholder: 'Email'  %>
     </div>
 
@@ -21,7 +21,7 @@
     </div>
 
     <div class="form-group">
-      <%= f.label :password_confirmation, class: 'sr-only' %><br />
+      <%= f.label :password_confirmation, class: 'sr-only' %>
       <%= f.password_field :password_confirmation, autocomplete: "off", size: 40, required: true, placeholder: 'Confirm password'  %>
     </div>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,27 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end -%>
+<div class="devise-links">
+	<%- if controller_name != 'sessions' %>
+	  <%= link_to "Log in", new_session_path(resource_name) %><br />
+	<% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end -%>
+	<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+	  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+	<% end -%>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end -%>
+	<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+	  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+	<% end -%>
 
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end -%>
+	<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+	  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+	<% end -%>
 
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end -%>
+	<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+	  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+	<% end -%>
 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
-  <% end -%>
-<% end -%>
+	<%- if devise_mapping.omniauthable? %>
+	  <%- resource_class.omniauth_providers.each do |provider| %>
+	    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+	  <% end -%>
+	<% end -%>
+</div>


### PR DESCRIPTION
I've fixed the Remember Me styling (Issue #93) and tweaked the Sign Up styling, as certain fields had more spacing than others due to <br> tags. I also spaced out the Devise links at the bottom. See these excessive comparison screenshots (old is on the right, new on left):

<div>
<img src="https://cloud.githubusercontent.com/assets/3187531/23194119/e819f04c-f871-11e6-88ee-c74d31ccc779.png" align="left" width="45%">
<img src="https://cloud.githubusercontent.com/assets/3187531/23194122/e829850c-f871-11e6-8edd-ce18809632e0.png" align="left" width="45%">
</div>
<img src="https://cloud.githubusercontent.com/assets/3187531/23194121/e823a128-f871-11e6-992d-e71ae51744d0.png" align="left" width="45%">
<img src="https://cloud.githubusercontent.com/assets/3187531/23194120/e81f763e-f871-11e6-8f39-48f50bd533cc.png" align="left" width="45%">
