### PR TITLE
120 restrict tweet edits to admins

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,4 +1,5 @@
 class TweetsController < ApplicationController
+  before_action :require_admin_status, only: [:edit, :update]
 
   def index
     @lesson = Lesson.find_by(id: params[:id])
@@ -42,30 +43,30 @@ class TweetsController < ApplicationController
   end
 
   def edit
-    if current_user.admin
-      @tweet = Tweet.find_by(id: params[:id])
-    else
-      redirect_to lessons_url
-    end
+    @tweet = Tweet.find_by(id: params[:id])
   end
 
   def update
-    if current_user.admin
-      tweet = Tweet.find_by(id: params[:id])
-      tweet.text = params[:tweet][:text]
-      tweet.cited_src = params[:tweet][:cited_src]
-      tweet.save
+    tweet = Tweet.find_by(id: params[:id])
+    tweet.text = params[:tweet][:text]
+    tweet.cited_src = params[:tweet][:cited_src]
+    tweet.save
 
-      contribution = Contribution.new
-      contribution.lesson_id = tweet.lesson_id
-      contribution.user_id = current_user.id
-      contribution.creator = false
-      contribution.save
+    contribution = Contribution.new
+    contribution.lesson_id = tweet.lesson_id
+    contribution.user_id = current_user.id
+    contribution.creator = false
+    contribution.save
 
-      redirect_to tweets_url(id: tweet.lesson_id)
-    else
+    redirect_to tweets_url(id: tweet.lesson_id)
+  end
+
+private
+
+  def require_admin_status
+    unless current_user.admin?
       redirect_to lessons_url
     end
-
   end
+
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -42,22 +42,30 @@ class TweetsController < ApplicationController
   end
 
   def edit
-    @tweet = Tweet.find_by(id: params[:id])
+    if current_user.admin
+      @tweet = Tweet.find_by(id: params[:id])
+    else
+      redirect_to lessons_url
+    end
   end
 
   def update
-    tweet = Tweet.find_by(id: params[:id])
-    tweet.text = params[:tweet][:text]
-    tweet.cited_src = params[:tweet][:cited_src]
-    tweet.save
+    if current_user.admin
+      tweet = Tweet.find_by(id: params[:id])
+      tweet.text = params[:tweet][:text]
+      tweet.cited_src = params[:tweet][:cited_src]
+      tweet.save
 
-    # create a new contribution for editor
-    contribution = Contribution.new
-    contribution.lesson_id = tweet.lesson_id
-    contribution.user_id = current_user.id
-    contribution.creator = false
-    contribution.save
+      contribution = Contribution.new
+      contribution.lesson_id = tweet.lesson_id
+      contribution.user_id = current_user.id
+      contribution.creator = false
+      contribution.save
 
-    redirect_to tweets_url(id: tweet.lesson_id)
+      redirect_to tweets_url(id: tweet.lesson_id)
+    else
+      redirect_to lessons_url
+    end
+
   end
 end

--- a/test/controllers/tweets_controller_test.rb
+++ b/test/controllers/tweets_controller_test.rb
@@ -8,6 +8,7 @@ class TweetsControllerTest < ActionController::TestCase
   def setup
     @lesson = lessons(:test_lesson)
     @tweet = tweet(:test_first_tweet)
+    #Controller tests bypass the router, which is where Devise sees what mappings to use before a request. The below lines tell Devise what mappings to use for a request from an admin or a non-admin user.
     @request.env["devise.mapping"] = Devise.mappings[:admin]
   end
 
@@ -17,47 +18,33 @@ class TweetsControllerTest < ActionController::TestCase
   end
 
   test "users signed in as admins can access the page to edit tweets" do
-    @admin = users(:admin)
-    @admin.confirmed_at = DateTime.now
-    @admin.save
     sign_in users(:admin)
     get :edit, id: @tweet.id
     assert_response :success
   end
 
   test "users who are not signed in as admins are redirected when they attempt to edit a lesson" do
-    @non_admin = users(:non_admin)
-    @non_admin.confirmed_at = DateTime.now
-    @non_admin.save
-    sign_in users(:non_admin)
+    sign_in users(:user)
     get :edit, id: @tweet.id
     assert_response :redirect
   end
 
   test "users signed in as admins can update tweets" do
-    skip("test did not work because tweet was sent to update method as 0 - commented out for now")
     @original_contribution_count = Contribution.all.length
-    @admin = users(:admin)
-    @admin.confirmed_at = DateTime.now
-    @admin.save
     sign_in users(:admin)
-    put :update, id: @tweet.id, tweet: @tweet, text: "new content"
+    put :update, id: @tweet.id, tweet: {text: "new content", source: "article"}
     assert_response :redirect
-    assert_redirected_to tweets_url(id: tweet.lesson_id)
-    assert_operator Contribution.all.length > @original_contribution_count
+    assert_redirected_to tweets_url(id: @tweet.lesson_id)
+    assert_operator(Contribution.all.length, :>, @original_contribution_count)
   end
 
-    test "users not signed in as admins cannot update tweets" do
-    skip("test did not work - commented out for now")
+  test "users not signed in as admins cannot update tweets" do
     @original_contribution_count = Contribution.all.length
-    @non_admin = users(:non_admin)
-    @non_admin.confirmed_at = DateTime.now
-    @non_admin.save
-    sign_in users(:non_admin)
-    put :update, params: {id: @tweet.id, tweet: {text: "new content", cited_src: "an article"}}
+    sign_in users(:user)
+    put :update, id: @tweet.id, tweet: {text: "new content", source: "article"}
     assert_response :redirect
     assert_redirected_to lessons_url
-    assert_operator Contribution.all.length == @original_contribution_count
+    assert_operator(Contribution.all.length, :==, @original_contribution_count)
   end
 
 end

--- a/test/controllers/tweets_controller_test.rb
+++ b/test/controllers/tweets_controller_test.rb
@@ -1,14 +1,63 @@
+require 'minitest/autorun'
 require 'test_helper'
+# require 'date'
 
 class TweetsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   def setup
     @lesson = lessons(:test_lesson)
+    @tweet = tweet(:test_first_tweet)
+    @request.env["devise.mapping"] = Devise.mappings[:admin]
   end
 
   test "get index" do
     get :index, id: @lesson.id
     assert_response :success
   end
+
+  test "users signed in as admins can access the page to edit tweets" do
+    @admin = users(:admin)
+    @admin.confirmed_at = DateTime.now
+    @admin.save
+    sign_in users(:admin)
+    get :edit, id: @tweet.id
+    assert_response :success
+  end
+
+  test "users who are not signed in as admins are redirected when they attempt to edit a lesson" do
+    @non_admin = users(:non_admin)
+    @non_admin.confirmed_at = DateTime.now
+    @non_admin.save
+    sign_in users(:non_admin)
+    get :edit, id: @tweet.id
+    assert_response :redirect
+  end
+
+  test "users signed in as admins can update tweets" do
+    skip("test did not work because tweet was sent to update method as 0 - commented out for now")
+    @original_contribution_count = Contribution.all.length
+    @admin = users(:admin)
+    @admin.confirmed_at = DateTime.now
+    @admin.save
+    sign_in users(:admin)
+    put :update, id: @tweet.id, tweet: @tweet, text: "new content"
+    assert_response :redirect
+    assert_redirected_to tweets_url(id: tweet.lesson_id)
+    assert_operator Contribution.all.length > @original_contribution_count
+  end
+
+    test "users not signed in as admins cannot update tweets" do
+    skip("test did not work - commented out for now")
+    @original_contribution_count = Contribution.all.length
+    @non_admin = users(:non_admin)
+    @non_admin.confirmed_at = DateTime.now
+    @non_admin.save
+    sign_in users(:non_admin)
+    put :update, params: {id: @tweet.id, tweet: {text: "new content", cited_src: "an article"}}
+    assert_response :redirect
+    assert_redirected_to lessons_url
+    assert_operator Contribution.all.length == @original_contribution_count
+  end
+
 end

--- a/test/fixtures/contribution.yml
+++ b/test/fixtures/contribution.yml
@@ -1,7 +1,7 @@
 one:
-  user: valid
+  user: user
   lesson: test_lesson
 
 two:
-  user: valid
+  user: user
   lesson: test_lesson_two

--- a/test/fixtures/tweet.yml
+++ b/test/fixtures/tweet.yml
@@ -1,5 +1,6 @@
 test_first_tweet:
   lesson_id: 0
+  id: 0
   text: "An alternative perspective."
   cited_src: "thoughtful dissertation"
   approved: true
@@ -9,6 +10,7 @@ test_first_tweet:
 
 test_second_tweet:
   lesson_id: 0
+  id: 1
   text: "A viewpoint worth hearing."
   cited_src: "personal narrative"
   approved: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,2 +1,18 @@
 valid:
   name: ChiHacker
+  email: chihacker@mystery.com
+  admin: true
+  how_found_tweechable: "a friend"
+
+non_admin:
+  name: Learner
+  email: learner@schooliscool.com
+  admin: false
+  how_found_tweechable: "a buddy"
+
+admin:
+  name: admin
+  email: admin@example.org
+  admin: true
+  # confirmed_at: Datetime.now
+  how_found_tweechable: "friend"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,18 +1,13 @@
-valid:
-  name: ChiHacker
-  email: chihacker@mystery.com
-  admin: true
-  how_found_tweechable: "a friend"
-
-non_admin:
+user:
   name: Learner
   email: learner@schooliscool.com
   admin: false
+  confirmed_at: 2017-09-10 14:50:39 -0500
   how_found_tweechable: "a buddy"
 
 admin:
   name: admin
   email: admin@example.org
   admin: true
-  # confirmed_at: Datetime.now
+  confirmed_at: 2017-09-10 14:50:39 -0500
   how_found_tweechable: "friend"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,6 @@
 class UserTest < ActiveSupport::TestCase
   def setup
-    @user = users(:valid)
+    @user = users(:user)
   end
 
   test '#contributions' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,12 +3,6 @@ class UserTest < ActiveSupport::TestCase
     @user = users(:valid)
   end
 
-  test 'invalid without name' do
-    @user.name = nil
-    refute @user.valid?
-    assert_not_nil @user.errors[:name]
-  end
-
   test '#contributions' do
     assert_equal 2, @user.contributions.size
   end


### PR DESCRIPTION
Hi @TheJhyde or @vkoves, could one of you please review this PR?  I made a few changes so that non-admins cannot edit lessons in response to issue #120.  Thanks.