### PR TITLE
show error flash notice when contact form doesn't work

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -11,7 +11,7 @@ class ContactsController < ApplicationController
       ContactMailer.contact_us(@contact).deliver_now
       flash.now[:notice] = 'Message valid.'
     else
-      flash.now[:error] = 'Cannot send message.'
+      flash.now[:alert] = 'Cannot send message.'
       render :new
     end
   end


### PR DESCRIPTION
I fixed the contact us form to show flash errors when someone doesn't successfully submit the contact us form.